### PR TITLE
feat(pypi): add BigQuery discovery backend for full fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,44 @@ paying a fresh TCP+TLS handshake per request. `PYPI_MAX_RPS` optionally caps the
 requests (set to `0`, the default, for no cap — concurrency is then bounded only by the
 worker count). HTTP 429 responses are always honored via the `Retry-After` header.
 
+#### Discovery backends (`--discovery` / `PYPI_DISCOVERY`)
+
+How the full (`-f`) fetch finds *which* packages to fetch:
+
+- **`simple`** (default) — brute-force the entire PyPI Simple index (~650k projects)
+  and download each project's JSON to check its classifier. No extra dependencies or
+  credentials, but it touches all of PyPI on every full run.
+- **`bigquery`** — filter by classifier **server-side** against the public
+  [`bigquery-public-data.pypi.distribution_metadata`](https://console.cloud.google.com/marketplace/product/gcp-public-data-pypi/pypi)
+  dataset, which exposes each distribution's `classifiers`. One query returns just the
+  matching project names (a few thousand for Plone); the metadata fetch then runs over
+  *those* names only — orders of magnitude fewer HTTP requests for a full run.
+
+```bash
+# brute-force (default)
+uv run pyfa pypi -f -t plone
+
+# server-side classifier discovery via BigQuery
+uv run pyfa pypi -f -t plone --discovery bigquery
+```
+
+The `bigquery` backend is optional. Install the extra and configure Google Cloud
+credentials (Application Default Credentials):
+
+```bash
+uv pip install 'pyf.aggregator[bigquery]'
+gcloud auth application-default login        # or set GOOGLE_APPLICATION_CREDENTIALS
+export BIGQUERY_PROJECT=my-gcp-project       # billing project for the query
+```
+
+Reading the public dataset is free, but BigQuery bills the **bytes scanned** to your
+billing project (a classifier-filtered scan is small and typically well within the
+free tier). The dataset is a periodic snapshot, so a freshly published package may lag
+by a short window — the incremental RSS path (`-i`) covers the gap, and the downstream
+`has_classifiers` re-check still drops anything that dropped the classifier since the
+snapshot. The `bigquery` backend only affects full-mode discovery; incremental updates
+always use the PyPI RSS feeds.
+
 ### npm Registry Rate Limits
 
 The npm registry does **not** publish a per-hour request limit. Its [acceptable-use

--- a/example.env
+++ b/example.env
@@ -21,6 +21,15 @@ PYPI_RETRY_BACKOFF=2.0
 PYPI_MAX_WORKERS=50
 # Batch size for memory-efficient fetching (default 500)
 PYPI_BATCH_SIZE=500
+# Discovery backend for the full (-f) fetch: "simple" brute-forces the whole PyPI
+# index (default, no extra deps); "bigquery" filters by classifier server-side via
+# the public BigQuery dataset, then fetches JSON only for the matches (orders of
+# magnitude fewer requests). bigquery needs the 'bigquery' extra + GCP credentials.
+PYPI_DISCOVERY=simple
+# BigQuery billing project (public dataset is free to read, but scanned bytes bill
+# to your project). Falls back to GOOGLE_CLOUD_PROJECT / the ADC default if unset.
+# BIGQUERY_PROJECT=my-gcp-project
+# BIGQUERY_PYPI_TABLE=bigquery-public-data.pypi.distribution_metadata
 
 # PyPI Stats API rate limiting (separate service)
 PYPISTATS_RATE_LIMIT_DELAY=2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,11 @@ test = [
 typecheck = [
     "pytest-stub",
 ]
+# Server-side classifier discovery via the public BigQuery PyPI dataset
+# (pyfa pypi -f --discovery bigquery / PYPI_DISCOVERY=bigquery).
+bigquery = [
+    "google-cloud-bigquery",
+]
 
 [project.scripts]
 pyfa = "pyf.aggregator.cli:main"

--- a/src/pyf/aggregator/bigquery_discovery.py
+++ b/src/pyf/aggregator/bigquery_discovery.py
@@ -1,0 +1,103 @@
+"""BigQuery-based package discovery for PyPI.
+
+The full ("first") fetch normally brute-forces the entire PyPI Simple index
+(~650k projects) and downloads each project's JSON just to check whether it
+carries the wanted classifier. That is the dominant cost of a full run.
+
+This module offers a server-side alternative: the public
+``bigquery-public-data.pypi.distribution_metadata`` table exposes each
+distribution's ``classifiers`` array, so a single SQL query returns only the
+project names that match the classifier filter. The downstream metadata fetch
+then runs over those few thousand names instead of all of PyPI.
+
+Optional: requires the ``bigquery`` extra (``google-cloud-bigquery``) and
+Google Cloud credentials (Application Default Credentials). Reading the public
+dataset is free, but BigQuery bills the bytes scanned to *your* billing
+project, so a project must be configured (``BIGQUERY_PROJECT`` /
+``GOOGLE_CLOUD_PROJECT`` or the ADC default).
+"""
+
+from pyf.aggregator.logger import logger
+
+import os
+
+
+try:  # google-cloud-bigquery is an optional dependency (the 'bigquery' extra)
+    from google.cloud import bigquery
+except ImportError:  # pragma: no cover - exercised via monkeypatch in tests
+    bigquery = None
+
+
+# Public dataset table holding per-distribution metadata including classifiers.
+BIGQUERY_PYPI_TABLE = os.getenv(
+    "BIGQUERY_PYPI_TABLE", "bigquery-public-data.pypi.distribution_metadata"
+)
+# Billing project for the query. The public dataset is free to read, but
+# BigQuery still bills the scanned bytes to a project of yours. Falls back to
+# the ADC default project when unset.
+BIGQUERY_PROJECT = os.getenv("BIGQUERY_PROJECT") or os.getenv("GOOGLE_CLOUD_PROJECT")
+
+
+def _build_client(project=None):
+    """Build a BigQuery client, raising a helpful error if the extra is missing."""
+    if bigquery is None:
+        raise RuntimeError(
+            "BigQuery discovery requires the 'bigquery' extra. Install it with: "
+            "uv pip install 'pyf.aggregator[bigquery]'"
+        )
+    return bigquery.Client(project=project or BIGQUERY_PROJECT)
+
+
+def discover_package_names(filter_classifiers, client=None, table=None):
+    """Return PyPI project names carrying any of the given classifier prefixes.
+
+    The match mirrors ``Aggregator.has_classifiers``: a project matches when any
+    of its classifiers *starts with* any filter prefix, so ``"Framework ::
+    Plone"`` also captures ``"Framework :: Plone :: 6.0"``.
+
+    Args:
+        filter_classifiers: A classifier prefix string or list of them.
+        client: Optional pre-built BigQuery client (injected in tests / reuse).
+        table: Optional fully-qualified table override.
+
+    Returns:
+        Sorted list of unique project names.
+    """
+    if bigquery is None and client is None:
+        # Surface the actionable install hint before doing anything else.
+        _build_client()
+
+    if isinstance(filter_classifiers, str):
+        filter_classifiers = [filter_classifiers]
+    filter_classifiers = [c for c in filter_classifiers if c]
+    if not filter_classifiers:
+        raise ValueError("BigQuery discovery requires at least one classifier")
+
+    client = client or _build_client()
+    table = table or BIGQUERY_PYPI_TABLE
+
+    # Match a project when ANY of its classifiers starts with ANY filter prefix.
+    conditions = " OR ".join(
+        f"STARTS_WITH(c, @cls{i})" for i in range(len(filter_classifiers))
+    )
+    query = (
+        "SELECT DISTINCT name\n"
+        f"FROM `{table}`\n"
+        "WHERE EXISTS (\n"
+        f"    SELECT 1 FROM UNNEST(classifiers) AS c WHERE {conditions}\n"
+        ")\n"
+        "ORDER BY name"
+    )
+    params = [
+        bigquery.ScalarQueryParameter(f"cls{i}", "STRING", c)
+        for i, c in enumerate(filter_classifiers)
+    ]
+    job_config = bigquery.QueryJobConfig(query_parameters=params)
+
+    logger.info(
+        f"Querying BigQuery {table} for packages matching {filter_classifiers}..."
+    )
+    rows = client.query(query, job_config=job_config).result()
+    names = [row["name"] for row in rows]
+    logger.info(f"BigQuery discovery returned {len(names)} package names")
+    return names

--- a/src/pyf/aggregator/fetcher.py
+++ b/src/pyf/aggregator/fetcher.py
@@ -51,6 +51,13 @@ PYPI_RETRY_BACKOFF = float(os.getenv("PYPI_RETRY_BACKOFF", 2.0))
 PYPI_MAX_WORKERS = int(os.getenv("PYPI_MAX_WORKERS", 50))
 # Batch size for memory-efficient parallel fetching (default 500)
 PYPI_BATCH_SIZE = int(os.getenv("PYPI_BATCH_SIZE", 500))
+# Discovery backend for the full ("first") fetch:
+#   "simple"   - brute-force the entire PyPI Simple index (default, no extra deps)
+#   "bigquery" - server-side classifier filter via the public BigQuery dataset,
+#                then fetch JSON only for the matching names (needs the
+#                'bigquery' extra + Google Cloud credentials). Orders of
+#                magnitude fewer requests for a full run.
+PYPI_DISCOVERY = os.getenv("PYPI_DISCOVERY", "simple")
 
 
 class Aggregator:
@@ -63,6 +70,7 @@ class Aggregator:
         filter_troove=None,
         skip_github=False,
         limit=None,
+        discovery=None,
     ):
         self.mode = mode
         self.sincefile = sincefile
@@ -71,6 +79,9 @@ class Aggregator:
         self.filter_troove = filter_troove
         self.skip_github = skip_github
         self.limit = limit
+        # Package-id discovery backend for full mode: "simple" | "bigquery".
+        # Falls back to the PYPI_DISCOVERY env var when not passed explicitly.
+        self.discovery = (discovery or PYPI_DISCOVERY).lower()
         self._fetch_counter = 0
         self._fetch_counter_lock = threading.Lock()
         self._total_packages = 0
@@ -249,6 +260,59 @@ class Aggregator:
 
     @property
     def _all_package_ids(self):
+        """Yield candidate package ids for the full fetch.
+
+        Dispatches on ``self.discovery``:
+          * "bigquery" - server-side classifier filter via the public BigQuery
+            dataset, yielding only matching project names.
+          * "simple" (default) - every project name from the PyPI Simple index;
+            classifier filtering then happens downstream in
+            ``_fetch_package_metadata`` on each package's JSON.
+        """
+        if self.discovery == "bigquery":
+            return self._all_package_ids_bigquery()
+        return self._all_package_ids_simple()
+
+    def _all_package_ids_bigquery(self):
+        """Yield package names discovered server-side via BigQuery.
+
+        These names already carry the classifier, so the downstream
+        ``has_classifiers`` re-check is a cheap defensive guard (it also drops
+        any package that removed the classifier since the dataset snapshot).
+        """
+        from pyf.aggregator.bigquery_discovery import discover_package_names
+
+        classifiers = self.filter_troove or [PLONE_CLASSIFIER]
+        if not self.filter_troove:
+            logger.warning(
+                "BigQuery discovery needs a classifier; defaulting to %s",
+                PLONE_CLASSIFIER,
+            )
+
+        names = discover_package_names(classifiers)
+
+        filtered_packages = [
+            name for name in names if not self.filter_name or self.filter_name in name
+        ]
+
+        if self.limit:
+            self._total_packages = min(len(filtered_packages), self.limit)
+        else:
+            self._total_packages = len(filtered_packages)
+
+        logger.info(
+            f"BigQuery discovery: {len(names)} matched classifier, "
+            f"{self._total_packages} to process."
+        )
+
+        count = 0
+        for package_id in filtered_packages:
+            if self.limit and count >= self.limit:
+                return
+            count += 1
+            yield package_id
+
+    def _all_package_ids_simple(self):
         """Get all package ids by pypi simple index.
 
         There is no server-side classifier filter in the supported PyPI APIs

--- a/src/pyf/aggregator/main.py
+++ b/src/pyf/aggregator/main.py
@@ -277,6 +277,15 @@ def add_subcommand_args(parser):
         action="store_true",
     )
     parser.add_argument(
+        "--discovery",
+        help="Package discovery backend for full (-f) mode: 'simple' brute-forces "
+        "the PyPI index (default); 'bigquery' filters by classifier server-side via "
+        "the public BigQuery dataset (needs the 'bigquery' extra + Google Cloud "
+        "credentials). Overrides the PYPI_DISCOVERY env var.",
+        choices=["simple", "bigquery"],
+        default=None,
+    )
+    parser.add_argument(
         "--refresh-from-pypi",
         help="Refresh indexed packages data from PyPi",
         action="store_true",
@@ -343,6 +352,7 @@ def run_command(args):
         "filter_troove": filter_troove,
         "limit": args.limit,
         "target": args.target,
+        "discovery": args.discovery,
     }
 
     logger.info(f"Starting PyPI aggregation in '{mode}' mode")
@@ -365,6 +375,7 @@ def run_command(args):
         filter_name=settings["filter_name"],
         filter_troove=settings["filter_troove"],
         limit=settings["limit"],
+        discovery=settings["discovery"],
     )
 
     indexer = Indexer()

--- a/tests/test_bigquery_discovery.py
+++ b/tests/test_bigquery_discovery.py
@@ -1,0 +1,126 @@
+"""Unit tests for BigQuery-based package discovery.
+
+The google-cloud-bigquery library is an optional extra and may not be
+installed, so these tests inject a fake ``bigquery`` module (the same surface
+the real one exposes: Client, ScalarQueryParameter, QueryJobConfig) via
+monkeypatch. No network or real credentials are used.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from pyf.aggregator import bigquery_discovery
+
+
+class FakeQueryJob:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def result(self):
+        return self._rows
+
+
+class FakeClient:
+    """Records the query/job_config it was called with and returns fixed rows."""
+
+    def __init__(self, rows=None, project=None):
+        self.project = project
+        self.captured = None
+        self._rows = (
+            rows
+            if rows is not None
+            else [
+                {"name": "collective.foo"},
+                {"name": "plone.api"},
+            ]
+        )
+
+    def query(self, query, job_config=None):
+        self.captured = SimpleNamespace(query=query, job_config=job_config)
+        return FakeQueryJob(self._rows)
+
+
+def make_fake_bigquery(client=None):
+    """A stand-in for ``google.cloud.bigquery`` with the bits we use."""
+    return SimpleNamespace(
+        Client=lambda project=None: client or FakeClient(project=project),
+        ScalarQueryParameter=lambda name, type_, value: SimpleNamespace(
+            name=name, type_=type_, value=value
+        ),
+        QueryJobConfig=lambda query_parameters=None: SimpleNamespace(
+            query_parameters=query_parameters or []
+        ),
+    )
+
+
+@pytest.fixture
+def fake_bq(monkeypatch):
+    fake = make_fake_bigquery()
+    monkeypatch.setattr(bigquery_discovery, "bigquery", fake)
+    return fake
+
+
+class TestDiscoverPackageNames:
+    def test_returns_names_from_rows(self, fake_bq):
+        client = FakeClient()
+        names = bigquery_discovery.discover_package_names(
+            "Framework :: Plone", client=client
+        )
+        assert names == ["collective.foo", "plone.api"]
+
+    def test_query_uses_starts_with_and_table(self, fake_bq):
+        client = FakeClient()
+        bigquery_discovery.discover_package_names(
+            "Framework :: Plone", client=client, table="proj.ds.tbl"
+        )
+        query = client.captured.query
+        assert "STARTS_WITH(c, @cls0)" in query
+        assert "`proj.ds.tbl`" in query
+        assert "UNNEST(classifiers)" in query
+        # One classifier -> one scalar parameter bound to its value.
+        params = client.captured.job_config.query_parameters
+        assert len(params) == 1
+        assert params[0].value == "Framework :: Plone"
+
+    def test_string_classifier_is_coerced_to_list(self, fake_bq):
+        client = FakeClient()
+        bigquery_discovery.discover_package_names("Framework :: Zope", client=client)
+        params = client.captured.job_config.query_parameters
+        assert [p.value for p in params] == ["Framework :: Zope"]
+
+    def test_multiple_classifiers_build_or_conditions(self, fake_bq):
+        client = FakeClient()
+        bigquery_discovery.discover_package_names(
+            ["Framework :: Plone", "Framework :: Zope"], client=client
+        )
+        query = client.captured.query
+        assert "STARTS_WITH(c, @cls0) OR STARTS_WITH(c, @cls1)" in query
+        params = client.captured.job_config.query_parameters
+        assert [p.value for p in params] == [
+            "Framework :: Plone",
+            "Framework :: Zope",
+        ]
+
+    def test_empty_values_are_dropped(self, fake_bq):
+        client = FakeClient()
+        bigquery_discovery.discover_package_names(
+            [None, "", "Framework :: Plone"], client=client
+        )
+        params = client.captured.job_config.query_parameters
+        assert [p.value for p in params] == ["Framework :: Plone"]
+
+    def test_empty_classifiers_raises(self, fake_bq):
+        with pytest.raises(ValueError, match="at least one classifier"):
+            bigquery_discovery.discover_package_names([], client=FakeClient())
+
+    def test_missing_library_raises_helpful_error(self, monkeypatch):
+        """With the extra not installed and no client injected, raise a hint."""
+        monkeypatch.setattr(bigquery_discovery, "bigquery", None)
+        with pytest.raises(RuntimeError, match=r"bigquery.*extra"):
+            bigquery_discovery.discover_package_names("Framework :: Plone")
+
+    def test_builds_client_when_none_given(self, fake_bq):
+        """When no client is injected, one is built from the (fake) library."""
+        names = bigquery_discovery.discover_package_names("Framework :: Plone")
+        assert names == ["collective.foo", "plone.api"]

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -752,6 +752,67 @@ class TestAllPackages:
 # ============================================================================
 
 
+class TestBigQueryDiscovery:
+    """Full-mode package-id discovery can route through BigQuery instead of
+    brute-forcing the PyPI Simple index."""
+
+    def test_default_discovery_is_simple(self):
+        assert Aggregator(mode="first").discovery == "simple"
+
+    def test_discovery_arg_overrides(self):
+        assert Aggregator(mode="first", discovery="bigquery").discovery == "bigquery"
+
+    def test_bigquery_routes_through_discover(self, monkeypatch):
+        """discovery='bigquery' yields names from discover_package_names,
+        applying the name filter, and passes the classifier filter through."""
+        captured = {}
+
+        def fake_discover(classifiers, **kwargs):
+            captured["classifiers"] = classifiers
+            return ["plone.api", "collective.foo", "requests"]
+
+        monkeypatch.setattr(
+            "pyf.aggregator.bigquery_discovery.discover_package_names",
+            fake_discover,
+        )
+
+        aggregator = Aggregator(
+            mode="first",
+            discovery="bigquery",
+            filter_troove=["Framework :: Plone"],
+            filter_name="plone",
+        )
+        ids = list(aggregator._all_package_ids)
+
+        assert captured["classifiers"] == ["Framework :: Plone"]
+        # Only names containing the filter substring are yielded.
+        assert ids == ["plone.api"]
+
+    def test_bigquery_respects_limit(self, monkeypatch):
+        monkeypatch.setattr(
+            "pyf.aggregator.bigquery_discovery.discover_package_names",
+            lambda classifiers, **kw: ["a", "b", "c", "d"],
+        )
+        aggregator = Aggregator(mode="first", discovery="bigquery", limit=2)
+        assert list(aggregator._all_package_ids) == ["a", "b"]
+
+    def test_bigquery_defaults_classifier_to_plone(self, monkeypatch):
+        """Without an explicit filter_troove, discovery falls back to Plone."""
+        captured = {}
+
+        def fake_discover(classifiers, **kwargs):
+            captured["classifiers"] = classifiers
+            return ["plone.api"]
+
+        monkeypatch.setattr(
+            "pyf.aggregator.bigquery_discovery.discover_package_names",
+            fake_discover,
+        )
+        aggregator = Aggregator(mode="first", discovery="bigquery")
+        list(aggregator._all_package_ids)
+        assert captured["classifiers"] == [PLONE_CLASSIFIER]
+
+
 class TestPloneClassifierConstant:
     """Test the PLONE_CLASSIFIER constant."""
 

--- a/tests/test_integration_profiles.py
+++ b/tests/test_integration_profiles.py
@@ -148,6 +148,7 @@ class TestCLIProfileIntegration:
                 filter_troove=[],
                 no_plone_filter=False,
                 force=False,
+                discovery=None,
             )
             run_command(args)
 
@@ -175,6 +176,7 @@ class TestCLIProfileIntegration:
                 filter_troove=[],
                 no_plone_filter=False,
                 force=False,
+                discovery=None,
             )
             with pytest.raises(SystemExit):
                 run_command(args)
@@ -209,6 +211,7 @@ class TestCLIProfileIntegration:
                 filter_troove=[],
                 no_plone_filter=False,
                 force=False,
+                discovery=None,
             )
             run_command(args)
 


### PR DESCRIPTION
Add an optional server-side package-discovery path as an alternative to brute-forcing the entire PyPI Simple index. The new bigquery backend queries the public bigquery-public-data.pypi.distribution_metadata table for project names carrying the wanted classifier, then fetches JSON only for those matches -- orders of magnitude fewer requests on a full run.

- New bigquery_discovery module: classifier-prefix query (STARTS_WITH, mirroring has_classifiers), lazy optional google-cloud-bigquery import so the base install and tests don't require it.
- Aggregator gains a discovery arg ("simple" default | "bigquery"), selectable via --discovery or the PYPI_DISCOVERY env var; _all_package_ids dispatches to the simple-index or BigQuery source. The simple path is unchanged and remains the default.
- google-cloud-bigquery added as the optional 'bigquery' extra.
- Docs: README discovery-backends section (creds, cost, freshness) and example.env entries.